### PR TITLE
Richlist GESN sync fix

### DIFF
--- a/tools/sync.js
+++ b/tools/sync.js
@@ -196,7 +196,7 @@ var writeTransactionsToDB = function(config, blockData, flush) {
           data[account].type = 1; // contract type
         }
 
-        web3.eth.getBalance(account, blockNumber, function(err, balance) {
+        web3.eth.getBalance(account, function(err, balance) {
           if (err) {
             console.log("ERROR: fail to getBalance(" + account + ")");
             return eachCallback(err);


### PR DESCRIPTION
to Fix ``[ ERROR: fail to getBalance .. ] `` error 

![unknown 1](https://user-images.githubusercontent.com/11604783/47002622-771d1a00-d168-11e8-8e12-0266864ddeef.png)

--
web3.eth.getBalance 함수에 블럭번호를 넣는경우에 발생하는 에러를 우회하기 위해
기본값 'latest' 으로 동작하게 하여 
tool/sync.js 가 동작하게 하기 위한 패치 입니다.